### PR TITLE
fix: use remote backend for web client

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -11,6 +11,13 @@ let callActive = false;  // flag indicating whether a call is in progress
 let clientSecret = null; // current client_secret token
 let modelName = null;    // realtime model name
 
+// Determine backend base URL. Use local server during development and
+// the Render deployment in production.
+const API_BASE =
+  window.location.hostname === "localhost"
+    ? "http://localhost:8000"
+    : "https://cutter.onrender.com";
+
 /**
  * Update the status indicator in the UI.
  * @param {string} state One of "connected", "connecting", or "disconnected".
@@ -44,7 +51,7 @@ async function startCall() {
   button.disabled = true;
   try {
     // Request a new client_secret and model name from our backend.
-    const response = await fetch("/session", { method: "POST" });
+    const response = await fetch(`${API_BASE}/session`, { method: "POST" });
     if (!response.ok) {
       throw new Error(`Server error: ${response.statusText}`);
     }

--- a/web/js/cutter-client.js
+++ b/web/js/cutter-client.js
@@ -1,4 +1,10 @@
-const API_BASE = "";
+// Choose backend URL based on environment.
+// Defaults to local development server, but uses the Render deployment when
+// the frontend is hosted elsewhere.
+export const API_BASE =
+  window.location.hostname === "localhost"
+    ? "http://localhost:8000"
+    : "https://cutter.onrender.com";
 
 async function api(path, options) {
   const res = await fetch(API_BASE + path, {


### PR DESCRIPTION
## Summary
- detect frontend hostname and choose proper backend base URL
- fetch session and API calls from `https://cutter.onrender.com` in production

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c8009966ec8330abb076277ebc7980