### PR TITLE
Fix realtime token parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Restore `/session` endpoint providing OpenAI realtime client tokens for the web frontend.
+- Fixed backend returning object for `client_secret`; now extracts token value so frontend sends valid Authorization header.
 
 ## 2025-09-15 — Voice handshake fix + health check
 - Fixed Realtime session creation: added required `OpenAI-Beta: realtime=v1` header.

--- a/routes/system.py
+++ b/routes/system.py
@@ -101,8 +101,11 @@ def create_realtime_session(request: Request):
                 detail={"error": {"code": "SESSION_CREATE_FAILED", "message": resp.text}},
             )
         data = resp.json()
+        client_secret = data.get("client_secret")
+        if isinstance(client_secret, dict):
+            client_secret = client_secret.get("value")
         return {
-            "client_secret": data.get("client_secret"),
+            "client_secret": client_secret,
             "model": data.get("model", OPENAI_REALTIME_MODEL),
         }
     except HTTPException:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -21,3 +21,29 @@ def test_session_returns_token():
     assert "client_secret" in data
     assert "model" in data
     assert data["client_secret"]
+
+
+def test_session_parses_nested_client_secret(monkeypatch):
+    rl.RATE_LIMIT_PER_MINUTE = 1000
+    system.OPENAI_API_KEY = "sk-test"
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {
+                "client_secret": {"value": "secret-token"},
+                "model": "gpt-test",
+            }
+
+    def fake_post(*args, **kwargs):
+        return FakeResp()
+
+    monkeypatch.setattr(system.httpx, "post", fake_post)
+    with TestClient(app) as client:
+        get_client().flushdb()
+        resp = client.post("/session")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["client_secret"] == "secret-token"
+    assert data["model"] == "gpt-test"

--- a/web/app.js
+++ b/web/app.js
@@ -64,7 +64,10 @@ async function startCall() {
       throw new Error(`Server error: ${response.statusText}`);
     }
     const data = await response.json();
-    clientSecret = data.client_secret;
+    clientSecret =
+      typeof data.client_secret === "object"
+        ? data.client_secret.value
+        : data.client_secret;
     modelName = data.model;
 
     // Create a new RTCPeerConnection and set up handlers.


### PR DESCRIPTION
## Summary
- extract `client_secret.value` from OpenAI realtime session response
- handle client_secret object on the frontend
- add regression test for realtime session token parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c811b5f9108330b8735b89f106353d